### PR TITLE
Add `concurrency` to checks

### DIFF
--- a/.github/workflows/README-check.yaml
+++ b/.github/workflows/README-check.yaml
@@ -8,6 +8,10 @@ on:
 
 name: README-check
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/dataset-check.yaml
+++ b/.github/workflows/dataset-check.yaml
@@ -6,6 +6,10 @@ on:
 
 name: dataset-check
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
This will prevent multiple runs of the same check that can collide, which can result in false negative failures.